### PR TITLE
[codex-cli] add DeepSeek API key prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,9 @@ export AZURE_OPENAI_API_VERSION="2025-03-01-preview" (Optional)
 # OpenRouter
 export OPENROUTER_API_KEY="your-openrouter-key-here"
 
+# DeepSeek
+export DEEPSEEK_API_KEY="your-deepseek-key-here"
+
 # Similarly for other providers
 ```
 

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -40,6 +40,7 @@ import {
 import {
   getApiKey as fetchApiKey,
   maybeRedeemCredits,
+  promptForApiKey,
 } from "./utils/get-api-key";
 import { createInputItem } from "./utils/input-utils";
 import { initLogger } from "./utils/logger/log";
@@ -327,38 +328,46 @@ try {
   // ignore errors
 }
 
-if (cli.flags.login) {
-  apiKey = await fetchApiKey(client.issuer, client.client_id);
-  try {
-    const home = os.homedir();
-    const authDir = path.join(home, ".codex");
-    const authFile = path.join(authDir, "auth.json");
-    if (fs.existsSync(authFile)) {
-      const data = JSON.parse(fs.readFileSync(authFile, "utf-8"));
-      savedTokens = data.tokens;
+if (provider.toLowerCase() === "openai") {
+  if (cli.flags.login) {
+    apiKey = await fetchApiKey(client.issuer, client.client_id);
+    try {
+      const home = os.homedir();
+      const authDir = path.join(home, ".codex");
+      const authFile = path.join(authDir, "auth.json");
+      if (fs.existsSync(authFile)) {
+        const data = JSON.parse(fs.readFileSync(authFile, "utf-8"));
+        savedTokens = data.tokens;
+      }
+    } catch {
+      /* ignore */
     }
-  } catch {
-    /* ignore */
+  } else if (!apiKey) {
+    apiKey = await fetchApiKey(client.issuer, client.client_id);
   }
-} else if (!apiKey) {
-  apiKey = await fetchApiKey(client.issuer, client.client_id);
-}
-// Ensure the API key is available as an environment variable for legacy code
-process.env["OPENAI_API_KEY"] = apiKey;
+  // Ensure the API key is available as an environment variable for legacy code
+  process.env["OPENAI_API_KEY"] = apiKey;
 
-if (cli.flags.free) {
-  // eslint-disable-next-line no-console
-  console.log(`${chalk.bold("codex --free")} attempting to redeem credits...`);
-  if (!savedTokens?.refresh_token) {
-    apiKey = await fetchApiKey(client.issuer, client.client_id, true);
-    // fetchApiKey includes credit redemption as the end of the flow
-  } else {
-    await maybeRedeemCredits(
-      client.issuer,
-      client.client_id,
-      savedTokens.refresh_token,
-      savedTokens.id_token,
-    );
+  if (cli.flags.free) {
+    // eslint-disable-next-line no-console
+    console.log(`${chalk.bold("codex --free")} attempting to redeem credits...`);
+    if (!savedTokens?.refresh_token) {
+      apiKey = await fetchApiKey(client.issuer, client.client_id, true);
+      // fetchApiKey includes credit redemption as the end of the flow
+    } else {
+      await maybeRedeemCredits(
+        client.issuer,
+        client.client_id,
+        savedTokens.refresh_token,
+        savedTokens.id_token,
+      );
+    }
+  }
+} else {
+  const envVar = `${provider.toUpperCase()}_API_KEY`;
+  apiKey = process.env[envVar] ?? "";
+  if (!apiKey) {
+    apiKey = await promptForApiKey(envVar, provider);
   }
 }
 

--- a/codex-cli/src/utils/get-api-key.tsx
+++ b/codex-cli/src/utils/get-api-key.tsx
@@ -5,13 +5,14 @@ import { ApiKeyPrompt, WaitingForAuth } from "./get-api-key-components";
 import chalk from "chalk";
 import express from "express";
 import fs from "fs/promises";
-import { render } from "ink";
+import { Box, Text, render } from "ink";
 import crypto from "node:crypto";
 import { URL } from "node:url";
 import open from "open";
 import os from "os";
 import path from "path";
 import React from "react";
+import TextInput from "../components/vendor/ink-text-input.js";
 
 function promptUserForChoice(): Promise<Choice> {
   return new Promise<Choice>((resolve) => {
@@ -759,6 +760,53 @@ export async function getApiKey(
     spinner.unmount();
     throw err;
   }
+}
+
+function PasteKeyPrompt({
+  providerName,
+  onDone,
+}: {
+  providerName: string;
+  onDone: (key: string) => void;
+}): JSX.Element {
+  const [apiKey, setApiKey] = React.useState("");
+
+  return (
+    <Box flexDirection="column">
+      <Text>
+        Paste your {providerName} API key and press &lt;Enter&gt;:
+      </Text>
+      <TextInput
+        value={apiKey}
+        onChange={setApiKey}
+        onSubmit={(value: string) => {
+          if (value.trim() !== "") {
+            onDone(value.trim());
+          }
+        }}
+        placeholder="sk-..."
+        mask="*"
+      />
+    </Box>
+  );
+}
+
+export async function promptForApiKey(
+  envVar: string,
+  providerName: string,
+): Promise<string> {
+  return new Promise<string>((resolve) => {
+    const instance = render(
+      <PasteKeyPrompt
+        providerName={providerName}
+        onDone={(key: string) => {
+          process.env[envVar] = key;
+          resolve(key);
+          instance.unmount();
+        }}
+      />,
+    );
+  });
 }
 
 export { maybeRedeemCredits };

--- a/codex-cli/tests/api-key.test.ts
+++ b/codex-cli/tests/api-key.test.ts
@@ -33,3 +33,24 @@ describe("config.setApiKey", () => {
     expect(liveRef).toBe("my‑key");
   });
 });
+
+describe("config.getApiKey provider env", () => {
+  const ORIGINAL_DEEPSEEK = process.env["DEEPSEEK_API_KEY"];
+
+  beforeEach(() => {
+    process.env["DEEPSEEK_API_KEY"] = "test-key";
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_DEEPSEEK !== undefined) {
+      process.env["DEEPSEEK_API_KEY"] = ORIGINAL_DEEPSEEK;
+    } else {
+      delete process.env["DEEPSEEK_API_KEY"];
+    }
+  });
+
+  it("reads provider specific API key", async () => {
+    const { getApiKey } = await import("../src/utils/config.js");
+    expect(getApiKey("deepseek")).toBe("test-key");
+  });
+});


### PR DESCRIPTION
## Summary
- prompt for DeepSeek API key when not set
- add example for `DEEPSEEK_API_KEY` in README
- expose `promptForApiKey` helper
- test config loading of DeepSeek API key

## Testing
- `pnpm lint --filter @openai/codex` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.8.1.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.8.1.tgz)*
- `pnpm typecheck` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.8.1.tgz)*